### PR TITLE
Misc bug fixes with defalut values

### DIFF
--- a/app/src/main/java/com/treefrogapps/multiprocesspreferences/MainActivity.java
+++ b/app/src/main/java/com/treefrogapps/multiprocesspreferences/MainActivity.java
@@ -14,6 +14,8 @@ public class MainActivity extends AppCompatActivity {
 
     private static final String STRING_KEY = "STRING_KEY";
     private static final String BOOLEAN_KEY = "BOOLEAN_KEY";
+    private static final String INTEGER_KEY = "INTEGER_KEY";
+
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -23,35 +25,21 @@ public class MainActivity extends AppCompatActivity {
         MultiPreferences preferences = new MultiPreferences(PREFS, getApplicationContext());
         preferences.clearPreferences();
 
-//        booleanTests(preferences);
-//        stringTests(preferences);
+        booleanTests(preferences);
+        stringTests(preferences);
+        intTests(preferences);
 
-        String val1;
-        String str;
-        val1 = "xxx";
-        Log.i(TAG, "Check set value " + val1);
-        preferences.setString(STRING_KEY, val1);
-        str = preferences.getString(STRING_KEY, "yyy");
-        if (!str.equals(val1)){
-            Log.e(TAG, "str should have set value " + val1 +", value was " + str);
-        } else {
-            Log.i(TAG, "Test pass");
-        }
-
-
-
-//        Log.i(TAG, "res=" + res);
-//        String input1= "user input 1";
-//        Log.i(TAG, "Setting STRING_KEY with =" + input1);
-//        preferences.setString(STRING_KEY, input1);
-//        res = preferences.getString(STRING_KEY, "default value");
-//        Log.i(TAG, "res=" + res);
-//        String input2= "";
-//        Log.i(TAG, "Setting STRING_KEY with =" + input2);
-//        preferences.setString(STRING_KEY, input2);
-//        res = preferences.getString(STRING_KEY, "default value");
-//        Log.i(TAG, "res=" + res);
-
+//        String val1;
+//        String str;
+//        val1 = "xxx";
+//        Log.i(TAG, "Check set value " + val1);
+//        preferences.setString(STRING_KEY, val1);
+//        str = preferences.getString(STRING_KEY, "yyy");
+//        if (!str.equals(val1)) {
+//            Log.e(TAG, "str should have set value " + val1 + ", value was " + str);
+//        } else {
+//            Log.i(TAG, "Test pass");
+//        }
 
 //
 //        long timebefore = System.currentTimeMillis();
@@ -86,11 +74,13 @@ public class MainActivity extends AppCompatActivity {
     }
 
     private void booleanTests(MultiPreferences preferences) {
+        Log.i(TAG, "================= booleanTests ===============");
+
         // getBoolean test
         boolean myboolean;
         Log.i(TAG, "Check get default value true");
         myboolean = preferences.getBoolean(BOOLEAN_KEY, true);
-        if (myboolean != true){
+        if (myboolean != true) {
             Log.e(TAG, "myboolean should have default value true, was " + myboolean);
         } else {
             Log.i(TAG, "Test pass");
@@ -99,7 +89,7 @@ public class MainActivity extends AppCompatActivity {
 
         Log.i(TAG, "Check get default value false");
         myboolean = preferences.getBoolean(BOOLEAN_KEY, false);
-        if (myboolean != false){
+        if (myboolean != false) {
             Log.e(TAG, "myboolean should have default value false, was " + myboolean);
         } else {
             Log.i(TAG, "Test pass");
@@ -110,7 +100,7 @@ public class MainActivity extends AppCompatActivity {
         Log.i(TAG, "Check set value true");
         preferences.setBoolean(BOOLEAN_KEY, true);
         myboolean = preferences.getBoolean(BOOLEAN_KEY, false);
-        if (myboolean != true){
+        if (myboolean != true) {
             Log.e(TAG, "myboolean should have set value true, was " + myboolean);
         } else {
             Log.i(TAG, "Test pass");
@@ -119,7 +109,7 @@ public class MainActivity extends AppCompatActivity {
         Log.i(TAG, "Check set value false");
         preferences.setBoolean(BOOLEAN_KEY, false);
         myboolean = preferences.getBoolean(BOOLEAN_KEY, true);
-        if (myboolean != false){
+        if (myboolean != false) {
             Log.e(TAG, "myboolean should have set value false, was " + myboolean);
         } else {
             Log.i(TAG, "Test pass");
@@ -127,12 +117,14 @@ public class MainActivity extends AppCompatActivity {
     }
 
     private void stringTests(MultiPreferences preferences) {
+        Log.i(TAG, "================= stringTests ===============");
+
         // getBoolean test
         String str;
         String val1 = "value1";
         Log.i(TAG, "Check get default value " + val1);
         str = preferences.getString(STRING_KEY, val1);
-        if (!str.equals(val1)){
+        if (!str.equals(val1)) {
             Log.e(TAG, "string should have default value " + val1 + ",was " + str);
         } else {
             Log.i(TAG, "Test pass");
@@ -142,7 +134,7 @@ public class MainActivity extends AppCompatActivity {
         val1 = "";
         Log.i(TAG, "Check get default value " + val1);
         str = preferences.getString(STRING_KEY, val1);
-        if (!str.equals(val1)){
+        if (!str.equals(val1)) {
             Log.e(TAG, "string should have default value " + val1 + ",was " + str);
         } else {
             Log.i(TAG, "Test pass");
@@ -153,8 +145,8 @@ public class MainActivity extends AppCompatActivity {
         Log.i(TAG, "Check set value " + val1);
         preferences.setString(STRING_KEY, val1);
         str = preferences.getString(STRING_KEY, "yyy");
-        if (!str.equals(val1)){
-            Log.e(TAG, "str should have set value " + val1 +", value was " + str);
+        if (!str.equals(val1)) {
+            Log.e(TAG, "str should have set value " + val1 + ", value was " + str);
         } else {
             Log.i(TAG, "Test pass");
         }
@@ -163,12 +155,57 @@ public class MainActivity extends AppCompatActivity {
         Log.i(TAG, "Check set empty string ");
         preferences.setString(STRING_KEY, val1);
         str = preferences.getString(STRING_KEY, "zzz");
-        if (!str.equals(val1)){
-            Log.e(TAG, "str should have set value " + val1 +", value was " + str);
+        if (!str.equals(val1)) {
+            Log.e(TAG, "str should have set value " + val1 + ", value was " + str);
         } else {
             Log.i(TAG, "Test pass");
         }
     }
 
+    private void intTests(MultiPreferences preferences) {
+        Log.i(TAG, "================= intTests ===============");
 
+        // getBoolean test
+        int anInt = 0;
+        int val1 = 100;
+
+        Log.i(TAG, "Check get default value " + val1);
+        anInt = preferences.getInt(INTEGER_KEY, val1);
+        if ( anInt != val1) {
+            Log.e(TAG, "int should have default value " + val1 + ",was " + anInt);
+        } else {
+            Log.i(TAG, "Test pass");
+        }
+        preferences.clearPreferences();
+
+        val1 = -1;
+        Log.i(TAG, "Check get default value " + val1);
+        anInt = preferences.getInt(INTEGER_KEY, val1);
+        if (anInt != val1) {
+            Log.e(TAG, "int should have default value " + val1 + ",was " + anInt);
+        } else {
+            Log.i(TAG, "Test pass");
+        }
+        preferences.clearPreferences();
+
+        val1 = 100;
+        Log.i(TAG, "Check set value " + val1);
+        preferences.setInt(INTEGER_KEY, val1);
+        anInt = preferences.getInt(INTEGER_KEY, 200);
+        if ( anInt != val1) {
+            Log.e(TAG, "int should have set value " + val1 + ", value was " + anInt);
+        } else {
+            Log.i(TAG, "Test pass");
+        }
+
+        val1 = -1;
+        Log.i(TAG, "Check set -1 int (defalut value of shared pref) ");
+        preferences.setInt(INTEGER_KEY, val1);
+        anInt = preferences.getInt(INTEGER_KEY, 300);
+        if (anInt != val1) {
+            Log.e(TAG, "int should have set value " + val1 + ", value was " + anInt);
+        } else {
+            Log.i(TAG, "Test pass");
+        }
+    }
 }

--- a/app/src/main/java/com/treefrogapps/multiprocesspreferences/MainActivity.java
+++ b/app/src/main/java/com/treefrogapps/multiprocesspreferences/MainActivity.java
@@ -12,6 +12,9 @@ public class MainActivity extends AppCompatActivity {
 
     private static final String PREFS = "APP_PREFS";
 
+    private static final String STRING_KEY = "STRING_KEY";
+    private static final String BOOLEAN_KEY = "BOOLEAN_KEY";
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -20,34 +23,52 @@ public class MainActivity extends AppCompatActivity {
 
         MultiPreferences preferences = new MultiPreferences(PREFS, getApplicationContext());
 
-        long timebefore = System.currentTimeMillis();
+        //String res = preferences.getString(STRING_KEY, "default value");
 
-        for (int i = 0; i < 1000; i++){
-
-            preferences.setString("string_key", "string_value");
-        }
-
-        long after = System.currentTimeMillis() - timebefore;
-
-        Log.e(TAG, "time to insert 1000 strings = " + after);
-
-        timebefore = System.currentTimeMillis();
-
-        for (int i = 0; i < 1000; i++){
-
-            preferences.getString("string_key", "not working");
-        }
+        boolean myboolean = preferences.getBoolean(BOOLEAN_KEY, true);
+        Log.i(TAG, "myboolean=" + myboolean);
+//        Log.i(TAG, "res=" + res);
+//        String input1= "user input 1";
+//        Log.i(TAG, "Setting STRING_KEY with =" + input1);
+//        preferences.setString(STRING_KEY, input1);
+//        res = preferences.getString(STRING_KEY, "default value");
+//        Log.i(TAG, "res=" + res);
+//        String input2= "";
+//        Log.i(TAG, "Setting STRING_KEY with =" + input2);
+//        preferences.setString(STRING_KEY, input2);
+//        res = preferences.getString(STRING_KEY, "default value");
+//        Log.i(TAG, "res=" + res);
 
 
-        after = System.currentTimeMillis() - timebefore;
-
-        Log.e(TAG, "time to retrieve 1000 strings = " + after);
-
-
-        preferences.setBoolean("boolean", false);
-
-        Log.e(TAG, preferences.getBoolean("boolean", true) + "");
-
+//
+//        long timebefore = System.currentTimeMillis();
+//
+//        for (int i = 0; i < 1000; i++){
+//
+//            preferences.setString("string_key", "string_value");
+//        }
+//
+//        long after = System.currentTimeMillis() - timebefore;
+//
+//        Log.e(TAG, "time to insert 1000 strings = " + after);
+//
+//        timebefore = System.currentTimeMillis();
+//
+//        for (int i = 0; i < 1000; i++){
+//
+//            preferences.getString("string_key", "not working");
+//        }
+//
+//
+//        after = System.currentTimeMillis() - timebefore;
+//
+//        Log.e(TAG, "time to retrieve 1000 strings = " + after);
+//
+//
+//        preferences.setBoolean("boolean", false);
+//
+//        Log.e(TAG, preferences.getBoolean("boolean", true) + "");
+//
         preferences.clearPreferences();
 
 

--- a/app/src/main/java/com/treefrogapps/multiprocesspreferences/MainActivity.java
+++ b/app/src/main/java/com/treefrogapps/multiprocesspreferences/MainActivity.java
@@ -20,13 +20,26 @@ public class MainActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
 
-
         MultiPreferences preferences = new MultiPreferences(PREFS, getApplicationContext());
+        preferences.clearPreferences();
 
-        //String res = preferences.getString(STRING_KEY, "default value");
+//        booleanTests(preferences);
+//        stringTests(preferences);
 
-        boolean myboolean = preferences.getBoolean(BOOLEAN_KEY, true);
-        Log.i(TAG, "myboolean=" + myboolean);
+        String val1;
+        String str;
+        val1 = "xxx";
+        Log.i(TAG, "Check set value " + val1);
+        preferences.setString(STRING_KEY, val1);
+        str = preferences.getString(STRING_KEY, "yyy");
+        if (!str.equals(val1)){
+            Log.e(TAG, "str should have set value " + val1 +", value was " + str);
+        } else {
+            Log.i(TAG, "Test pass");
+        }
+
+
+
 //        Log.i(TAG, "res=" + res);
 //        String input1= "user input 1";
 //        Log.i(TAG, "Setting STRING_KEY with =" + input1);
@@ -70,10 +83,91 @@ public class MainActivity extends AppCompatActivity {
 //        Log.e(TAG, preferences.getBoolean("boolean", true) + "");
 //
         preferences.clearPreferences();
+    }
+
+    private void booleanTests(MultiPreferences preferences) {
+        // getBoolean test
+        boolean myboolean;
+        Log.i(TAG, "Check get default value true");
+        myboolean = preferences.getBoolean(BOOLEAN_KEY, true);
+        if (myboolean != true){
+            Log.e(TAG, "myboolean should have default value true, was " + myboolean);
+        } else {
+            Log.i(TAG, "Test pass");
+        }
+        preferences.clearPreferences();
+
+        Log.i(TAG, "Check get default value false");
+        myboolean = preferences.getBoolean(BOOLEAN_KEY, false);
+        if (myboolean != false){
+            Log.e(TAG, "myboolean should have default value false, was " + myboolean);
+        } else {
+            Log.i(TAG, "Test pass");
+        }
+        preferences.clearPreferences();
 
 
+        Log.i(TAG, "Check set value true");
+        preferences.setBoolean(BOOLEAN_KEY, true);
+        myboolean = preferences.getBoolean(BOOLEAN_KEY, false);
+        if (myboolean != true){
+            Log.e(TAG, "myboolean should have set value true, was " + myboolean);
+        } else {
+            Log.i(TAG, "Test pass");
+        }
 
+        Log.i(TAG, "Check set value false");
+        preferences.setBoolean(BOOLEAN_KEY, false);
+        myboolean = preferences.getBoolean(BOOLEAN_KEY, true);
+        if (myboolean != false){
+            Log.e(TAG, "myboolean should have set value false, was " + myboolean);
+        } else {
+            Log.i(TAG, "Test pass");
+        }
+    }
 
+    private void stringTests(MultiPreferences preferences) {
+        // getBoolean test
+        String str;
+        String val1 = "value1";
+        Log.i(TAG, "Check get default value " + val1);
+        str = preferences.getString(STRING_KEY, val1);
+        if (!str.equals(val1)){
+            Log.e(TAG, "string should have default value " + val1 + ",was " + str);
+        } else {
+            Log.i(TAG, "Test pass");
+        }
+        preferences.clearPreferences();
+
+        val1 = "";
+        Log.i(TAG, "Check get default value " + val1);
+        str = preferences.getString(STRING_KEY, val1);
+        if (!str.equals(val1)){
+            Log.e(TAG, "string should have default value " + val1 + ",was " + str);
+        } else {
+            Log.i(TAG, "Test pass");
+        }
+        preferences.clearPreferences();
+
+        val1 = "xxx";
+        Log.i(TAG, "Check set value " + val1);
+        preferences.setString(STRING_KEY, val1);
+        str = preferences.getString(STRING_KEY, "yyy");
+        if (!str.equals(val1)){
+            Log.e(TAG, "str should have set value " + val1 +", value was " + str);
+        } else {
+            Log.i(TAG, "Test pass");
+        }
+
+        val1 = "";
+        Log.i(TAG, "Check set empty string ");
+        preferences.setString(STRING_KEY, val1);
+        str = preferences.getString(STRING_KEY, "zzz");
+        if (!str.equals(val1)){
+            Log.e(TAG, "str should have set value " + val1 +", value was " + str);
+        } else {
+            Log.i(TAG, "Test pass");
+        }
     }
 
 

--- a/app/src/main/java/com/treefrogapps/multiprocesspreferences/MainActivity.java
+++ b/app/src/main/java/com/treefrogapps/multiprocesspreferences/MainActivity.java
@@ -15,6 +15,7 @@ public class MainActivity extends AppCompatActivity {
     private static final String STRING_KEY = "STRING_KEY";
     private static final String BOOLEAN_KEY = "BOOLEAN_KEY";
     private static final String INTEGER_KEY = "INTEGER_KEY";
+    private static final String LONG_KEY = "LONG_KEY";
 
 
     @Override
@@ -25,53 +26,67 @@ public class MainActivity extends AppCompatActivity {
         MultiPreferences preferences = new MultiPreferences(PREFS, getApplicationContext());
         preferences.clearPreferences();
 
+        Log.i(TAG, "========= functionality  tests ===============");
+        cleaningTest(preferences);
         booleanTests(preferences);
         stringTests(preferences);
         intTests(preferences);
+        longTests(preferences);
 
-//        String val1;
-//        String str;
-//        val1 = "xxx";
-//        Log.i(TAG, "Check set value " + val1);
-//        preferences.setString(STRING_KEY, val1);
-//        str = preferences.getString(STRING_KEY, "yyy");
-//        if (!str.equals(val1)) {
-//            Log.e(TAG, "str should have set value " + val1 + ", value was " + str);
-//        } else {
-//            Log.i(TAG, "Test pass");
-//        }
 
-//
-//        long timebefore = System.currentTimeMillis();
-//
-//        for (int i = 0; i < 1000; i++){
-//
-//            preferences.setString("string_key", "string_value");
-//        }
-//
-//        long after = System.currentTimeMillis() - timebefore;
-//
-//        Log.e(TAG, "time to insert 1000 strings = " + after);
-//
-//        timebefore = System.currentTimeMillis();
-//
-//        for (int i = 0; i < 1000; i++){
-//
-//            preferences.getString("string_key", "not working");
-//        }
-//
-//
-//        after = System.currentTimeMillis() - timebefore;
-//
-//        Log.e(TAG, "time to retrieve 1000 strings = " + after);
-//
-//
-//        preferences.setBoolean("boolean", false);
-//
-//        Log.e(TAG, preferences.getBoolean("boolean", true) + "");
-//
+        Log.i(TAG, "========= Performance tests ===============");
+
+        long timebefore = System.currentTimeMillis();
+
+        for (int i = 0; i < 1000; i++){
+
+            preferences.setString("string_key", "string_value");
+        }
+
+        long after = System.currentTimeMillis() - timebefore;
+
+        Log.e(TAG, "time to insert 1000 strings = " + after);
+
+        timebefore = System.currentTimeMillis();
+
+        for (int i = 0; i < 1000; i++){
+
+            preferences.getString("string_key", "not working");
+        }
+
+
+        after = System.currentTimeMillis() - timebefore;
+
+        Log.e(TAG, "time to retrieve 1000 strings = " + after);
+
+
+        preferences.setBoolean("boolean", false);
+
+        Log.e(TAG, preferences.getBoolean("boolean", true) + "");
+
         preferences.clearPreferences();
     }
+
+    private void cleaningTest(MultiPreferences preferences) {
+        Log.i(TAG, "================= cleaningTest ===============");
+        preferences.clearPreferences();
+
+        int val1 = 0;
+        int anInt;
+        val1 = 100;
+        Log.i(TAG, "Check cleaning setting value " + val1);
+        preferences.setInt(INTEGER_KEY, val1);
+        preferences.clearPreferences();
+
+        int defaultValue = 200;
+        anInt = preferences.getInt(INTEGER_KEY, defaultValue);
+        if ( anInt != defaultValue) {
+            Log.e(TAG, "cleaning did not work , return value is " + anInt + ", while it should have been " + defaultValue);
+        } else {
+            Log.i(TAG, "Test pass");
+        }
+    }
+
 
     private void booleanTests(MultiPreferences preferences) {
         Log.i(TAG, "================= booleanTests ===============");
@@ -204,6 +219,53 @@ public class MainActivity extends AppCompatActivity {
         anInt = preferences.getInt(INTEGER_KEY, 300);
         if (anInt != val1) {
             Log.e(TAG, "int should have set value " + val1 + ", value was " + anInt);
+        } else {
+            Log.i(TAG, "Test pass");
+        }
+    }
+
+    private void longTests(MultiPreferences preferences) {
+        Log.i(TAG, "================= longTests ===============");
+
+        // getBoolean test
+        long aLong = 0L;
+        long val1 = 100L;
+
+        Log.i(TAG, "Check get default value " + val1);
+        aLong = preferences.getLong(LONG_KEY, val1);
+        if ( aLong != val1) {
+            Log.e(TAG, "long should have default value " + val1 + ",was " + aLong);
+        } else {
+            Log.i(TAG, "Test pass");
+        }
+        preferences.clearPreferences();
+
+        val1 = -1L;
+        Log.i(TAG, "Check get default value " + val1);
+        aLong = preferences.getLong(LONG_KEY, val1);
+        if (aLong != val1) {
+            Log.e(TAG, "long should have default value " + val1 + ",was " + aLong);
+        } else {
+            Log.i(TAG, "Test pass");
+        }
+        preferences.clearPreferences();
+
+        val1 = 100L;
+        Log.i(TAG, "Check set value " + val1);
+        preferences.setLong(LONG_KEY, val1);
+        aLong = preferences.getLong(LONG_KEY, 200L);
+        if ( aLong != val1) {
+            Log.e(TAG, "long should have set value " + val1 + ", value was " + aLong);
+        } else {
+            Log.i(TAG, "Test pass");
+        }
+
+        val1 = -1L;
+        Log.i(TAG, "Check set -1 long (defalut value of shared pref) ");
+        preferences.setLong(LONG_KEY, val1);
+        aLong = preferences.getLong(LONG_KEY, 300L);
+        if (aLong != val1) {
+            Log.e(TAG, "long should have set value " + val1 + ", value was " + aLong);
         } else {
             Log.i(TAG, "Test pass");
         }

--- a/app/src/main/java/com/treefrogapps/multiprocesspreferences/multi_preferences/MultiPreferences.java
+++ b/app/src/main/java/com/treefrogapps/multiprocesspreferences/multi_preferences/MultiPreferences.java
@@ -79,22 +79,15 @@ public class MultiPreferences {
     }
 
     public long getLong(final String key, final long defaultValue) {
-
-        long value = defaultValue;
-
         Uri queryUri = MultiProvider.createQueryUri(mName, key, MultiProvider.CODE_LONG);
-
         Cursor cursor = mContext.getContentResolver().query(queryUri, null, null, null, null, null);
-
         if(cursor != null && cursor.moveToFirst()){
-            int tempValue = cursor.getInt(cursor.getColumnIndexOrThrow(MultiProvider.VALUE));
-            if(tempValue != -1) {
-                value = tempValue;
-            }
+            long result = cursor.getInt(cursor.getColumnIndexOrThrow(MultiProvider.VALUE));
             cursor.close();
+            return result;
+        } else {
+            return defaultValue;
         }
-
-        return value;
     }
 
 

--- a/app/src/main/java/com/treefrogapps/multiprocesspreferences/multi_preferences/MultiPreferences.java
+++ b/app/src/main/java/com/treefrogapps/multiprocesspreferences/multi_preferences/MultiPreferences.java
@@ -25,33 +25,23 @@ public class MultiPreferences {
 
 
     public void setString(final String key, final String value) {
-
         Uri updateUri = MultiProvider.createQueryUri(mName, key, MultiProvider.CODE_STRING);
-
         ContentValues contentValues = new ContentValues();
         contentValues.put(MultiProvider.KEY, key);
         contentValues.put(MultiProvider.VALUE, value);
-
         mContext.getContentResolver().update(updateUri, contentValues, null, null);
     }
 
     public String getString(final String key, final String defaultValue) {
-
-        String value = defaultValue;
-
         Uri queryUri = MultiProvider.createQueryUri(mName, key, MultiProvider.CODE_STRING);
-
         Cursor cursor = mContext.getContentResolver().query(queryUri, null, null, null, null, null);
-
         if(cursor != null && cursor.moveToFirst()){
-            String tempValue = cursor.getString(cursor.getColumnIndexOrThrow(MultiProvider.VALUE));
-            if(!tempValue.equals("")){
-                value = tempValue;
-            }
+            String result = cursor.getString(cursor.getColumnIndexOrThrow(MultiProvider.VALUE));
             cursor.close();
+            return result;
+        } else {
+            return defaultValue;
         }
-
-        return value;
     }
 
     public void setInt(final String key, final int value) {
@@ -136,11 +126,12 @@ public class MultiPreferences {
 
         if(cursor != null && cursor.moveToFirst()){
             int tempValue = cursor.getInt(cursor.getColumnIndexOrThrow(MultiProvider.VALUE));
-            if(tempValue != value) {
-                value = tempValue;
-            }
             cursor.close();
-            return true;
+            if(tempValue == 1) {
+                return true;
+            } else {
+                return false;
+            }
         } else {
             return defaultValue;
         }

--- a/app/src/main/java/com/treefrogapps/multiprocesspreferences/multi_preferences/MultiPreferences.java
+++ b/app/src/main/java/com/treefrogapps/multiprocesspreferences/multi_preferences/MultiPreferences.java
@@ -56,22 +56,15 @@ public class MultiPreferences {
     }
 
     public int getInt(final String key, final int defaultValue) {
-
-        int value = defaultValue;
-
         Uri queryUri = MultiProvider.createQueryUri(mName, key, MultiProvider.CODE_INTEGER);
-
         Cursor cursor = mContext.getContentResolver().query(queryUri, null, null, null, null, null);
-
         if(cursor != null && cursor.moveToFirst()){
-            int tempValue = cursor.getInt(cursor.getColumnIndexOrThrow(MultiProvider.VALUE));
-            if(tempValue != -1) {
-                value = tempValue;
-            }
+            int result = cursor.getInt(cursor.getColumnIndexOrThrow(MultiProvider.VALUE));
             cursor.close();
+            return result;
+        } else {
+            return defaultValue;
         }
-
-        return value;
     }
 
     public void setLong(final String key, final long value) {

--- a/app/src/main/java/com/treefrogapps/multiprocesspreferences/multi_preferences/MultiPreferences.java
+++ b/app/src/main/java/com/treefrogapps/multiprocesspreferences/multi_preferences/MultiPreferences.java
@@ -140,9 +140,10 @@ public class MultiPreferences {
                 value = tempValue;
             }
             cursor.close();
+            return true;
+        } else {
+            return defaultValue;
         }
-
-        return value == 1;
     }
 
     public void removePreference(final String key) {

--- a/app/src/main/java/com/treefrogapps/multiprocesspreferences/multi_preferences/MultiProvider.java
+++ b/app/src/main/java/com/treefrogapps/multiprocesspreferences/multi_preferences/MultiProvider.java
@@ -152,7 +152,8 @@ public class MultiProvider extends ContentProvider {
                     return preferenceToCursor(result ? 1 : 0);
                 }
         }
-
+        // Notify subscriber for this URI.
+        getContext().getContentResolver().notifyChange(uri, null);
         return null;
     }
 

--- a/app/src/main/java/com/treefrogapps/multiprocesspreferences/multi_preferences/MultiProvider.java
+++ b/app/src/main/java/com/treefrogapps/multiprocesspreferences/multi_preferences/MultiProvider.java
@@ -109,10 +109,16 @@ public class MultiProvider extends ContentProvider {
      */
     private <T> MatrixCursor preferenceToCursor(T value) {
 
-        MatrixCursor matrixCursor = new MatrixCursor(new String[]{MultiProvider.VALUE}, 1);
-        MatrixCursor.RowBuilder builder = matrixCursor.newRow();
-        builder.add(value);
-        return matrixCursor;
+        if (value != null) {
+            MatrixCursor matrixCursor = new MatrixCursor(new String[]{MultiProvider.VALUE}, 1);
+            MatrixCursor.RowBuilder builder = matrixCursor.newRow();
+            builder.add(value);
+            return matrixCursor;
+        } else {
+            return null;
+            //return new MatrixCursor(new String[]{MultiProvider.VALUE}, 0);
+        }
+
     }
 
 
@@ -138,7 +144,13 @@ public class MultiProvider extends ContentProvider {
                 return preferenceToCursor(interactor.getLong(uri.getPathSegments().get(2), -1));
 
             case CODE_BOOLEAN:
-                return preferenceToCursor(interactor.getBoolean(uri.getPathSegments().get(2), false) ? 1 : 0);
+                Boolean result =  interactor.getBoolean(uri.getPathSegments().get(2), false);
+                if (result == null){
+                    return null;
+                } else
+                {
+                    return preferenceToCursor(result ? 1 : 0);
+                }
         }
 
         return null;

--- a/app/src/main/java/com/treefrogapps/multiprocesspreferences/multi_preferences/PreferenceInteractor.java
+++ b/app/src/main/java/com/treefrogapps/multiprocesspreferences/multi_preferences/PreferenceInteractor.java
@@ -36,8 +36,11 @@ public class PreferenceInteractor {
     }
 
     public Integer getInt(String key, int defaultVal){
-        return mSharedPreferences.getInt(key, defaultVal);
-
+        if (mSharedPreferences.contains(key)){
+            return mSharedPreferences.getInt(key, defaultVal);
+        } else {
+            return null;
+        }
     }
 
     public void setInt(String key, int value){
@@ -45,8 +48,11 @@ public class PreferenceInteractor {
     }
 
     public Long getLong(String key, long defaultVal){
-        return mSharedPreferences.getLong(key, defaultVal);
-
+        if (mSharedPreferences.contains(key)){
+            return mSharedPreferences.getLong(key, defaultVal);
+        } else {
+            return null;
+        }
     }
 
     public void setLong(String key, long value){

--- a/app/src/main/java/com/treefrogapps/multiprocesspreferences/multi_preferences/PreferenceInteractor.java
+++ b/app/src/main/java/com/treefrogapps/multiprocesspreferences/multi_preferences/PreferenceInteractor.java
@@ -23,18 +23,19 @@ public class PreferenceInteractor {
                 = mContext.getSharedPreferences(mPreferenceName, Context.MODE_PRIVATE);
     }
 
-
-
-
     public String getString(String key, String defaultVal){
-     return mSharedPreferences.getString(key, defaultVal);
+        if (mSharedPreferences.contains(key)) {
+            return mSharedPreferences.getString(key, defaultVal);
+        } else {
+            return null;
+        }
     }
 
     public void setString(String key, String value){
         mSharedPreferences.edit().putString(key, value).apply();
     }
 
-    public int getInt(String key, int defaultVal){
+    public Integer getInt(String key, int defaultVal){
         return mSharedPreferences.getInt(key, defaultVal);
 
     }
@@ -43,7 +44,7 @@ public class PreferenceInteractor {
         mSharedPreferences.edit().putInt(key, value).apply();
     }
 
-    public long getLong(String key, long defaultVal){
+    public Long getLong(String key, long defaultVal){
         return mSharedPreferences.getLong(key, defaultVal);
 
     }
@@ -52,8 +53,12 @@ public class PreferenceInteractor {
         mSharedPreferences.edit().putLong(key, value).apply();
     }
 
-    public boolean getBoolean(String key, boolean defaultVal){
-        return mSharedPreferences.getBoolean(key, defaultVal);
+    public Boolean getBoolean(String key, boolean defaultVal){
+        if (mSharedPreferences.contains(key)) {
+            return mSharedPreferences.getBoolean(key, defaultVal);
+        } else {
+            return null;
+        }
     }
 
     public void setBoolean(String key, boolean value){


### PR DESCRIPTION
Some bug fixes
* Reading boolean when no value is store always return false, regardless value specified in the default value of the call
* When setting a value which is the same value as default shared preference value set in MultiProvider in query function when calling interactor get method (e.g: -1 for int) 
will result result with default value of the caller, and not real value set by user.

Main activity was added with test to verify these bugs fix in this commit.

Also – query was update to notify observers subscribe for changes in the URI.
